### PR TITLE
Add README, upgrade node-addon-api, and cmake to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(node_window_rendering)
 
 if(APPLE)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # node-window-rendering
 Node module to create and render textures on child windows
+
+## How to build
+
+```
+yarn install
+mkdir build
+cd build
+cmake .. -G "Xcode" -DCMAKE_INSTALL_PREFIX=dist
+cmake --build . --target install
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,10 +77,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-node-addon-api@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.0.0.tgz#8136add2f510997b3b94814f4af1cce0b0e3962e"
-  integrity sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==
+node-addon-api@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
- Adding a README file describing how to build the project locally.
- When I ran `yarn install` the node-addon package was updated. So checking in the yarn.lock file
- Upgrade CMAKE to fix issue

How was this Tested?
I built this package locally a few weeks ago when I was upgrading mac to obs-30.2. Thought I should put up a PR containing the updates I made.